### PR TITLE
Restrict & Limit Public API surface for simplicity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ ktor3-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor3" 
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 
 [plugins]
 

--- a/podcastindex-ktor2/src/commonMain/kotlin/com/mr3y/podcastindex/ktor2/PodcastIndexClient.kt
+++ b/podcastindex-ktor2/src/commonMain/kotlin/com/mr3y/podcastindex/ktor2/PodcastIndexClient.kt
@@ -1,6 +1,5 @@
 package com.mr3y.podcastindex.ktor2
 
-import com.mr3y.podcastindex.Authentication
 import com.mr3y.podcastindex.PodcastIndexClient
 import com.mr3y.podcastindex.PodcastIndexClientConfig
 import com.mr3y.podcastindex.PodcastIndexConfigDsl
@@ -24,12 +23,11 @@ public fun PodcastIndexClient(
     block: PodcastIndexClientConfig.() -> Unit = {},
 ): PodcastIndexClient {
     require(userAgent.isNotBlank()) { "User agent cannot be blank" }
-    val auth = Authentication(authKey, authSecret, userAgent)
     val config = PodcastIndexClientConfig().apply { block() }
     return PodcastIndexClient(
         httpClientConfig = {
-            installAuthenticationPlugin(auth)
-            installRetryPlugin(auth, maxRetries = config.maxRetries)
+            installAuthenticationPlugin(authKey, authSecret, userAgent)
+            installRetryPlugin(authKey, authSecret, maxRetries = config.maxRetries)
             installSerializationPlugin()
             if (config.enableLogging) {
                 installLoggingPlugin(config.loggingTag)

--- a/podcastindex-ktor3/src/commonMain/kotlin/com/mr3y/podcastindex/ktor3/HttpClient.kt
+++ b/podcastindex-ktor3/src/commonMain/kotlin/com/mr3y/podcastindex/ktor3/HttpClient.kt
@@ -1,6 +1,5 @@
 package com.mr3y.podcastindex.ktor3
 
-import com.mr3y.podcastindex.Authentication
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
@@ -17,17 +16,17 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import co.touchlab.kermit.Logger as KermitLogger
 
-internal fun HttpClientConfig<*>.installAuthenticationPlugin(authenticationInfo: Authentication) {
+internal fun HttpClientConfig<*>.installAuthenticationPlugin(key: String, secret: String, userAgent: String) {
     // Add the necessary authentication headers to every request going out to PodcastIndex endpoints
     val requestAuthenticationPlugin = createClientPlugin("requestAuthenticatorPlugin") {
         onRequest { request, _ ->
             if (request.url.pathSegments.drop(3)[0] != "value") {
                 request.headers {
                     val epoch = (Clock.System.now().toEpochMilliseconds() / 1000)
-                    append("User-Agent", authenticationInfo.userAgent)
+                    append("User-Agent", userAgent)
                     append("X-Auth-Date", epoch.toString())
-                    append("X-Auth-Key", authenticationInfo.key)
-                    append("Authorization", authHeader(epoch, authenticationInfo.key, authenticationInfo.secret))
+                    append("X-Auth-Key", key)
+                    append("Authorization", authHeader(epoch, key, secret))
                 }
             }
         }
@@ -35,7 +34,7 @@ internal fun HttpClientConfig<*>.installAuthenticationPlugin(authenticationInfo:
     install(requestAuthenticationPlugin)
 }
 
-internal fun HttpClientConfig<*>.installRetryPlugin(authenticationInfo: Authentication, maxRetries: Int) {
+internal fun HttpClientConfig<*>.installRetryPlugin(key: String, secret: String, maxRetries: Int) {
     install(HttpRequestRetry) {
         modifyRequest { request ->
             if (request.url.pathSegments.drop(3)[0] != "value") {
@@ -44,7 +43,7 @@ internal fun HttpClientConfig<*>.installRetryPlugin(authenticationInfo: Authenti
                 // to solve this, retry the request with a 1.5 minutes offset.
                 val epoch = (Clock.System.now().toEpochMilliseconds() / 1000) - 150
                 request.headers["X-Auth-Date"] = epoch.toString()
-                request.headers["Authorization"] = authHeader(epoch, authenticationInfo.key, authenticationInfo.secret)
+                request.headers["Authorization"] = authHeader(epoch, key, secret)
             }
         }
         retryIf(maxRetries) { _, httpResponse ->

--- a/podcastindex-ktor3/src/commonMain/kotlin/com/mr3y/podcastindex/ktor3/PodcastIndexClient.kt
+++ b/podcastindex-ktor3/src/commonMain/kotlin/com/mr3y/podcastindex/ktor3/PodcastIndexClient.kt
@@ -1,6 +1,5 @@
 package com.mr3y.podcastindex.ktor3
 
-import com.mr3y.podcastindex.Authentication
 import com.mr3y.podcastindex.PodcastIndexClient
 import com.mr3y.podcastindex.PodcastIndexClientConfig
 import com.mr3y.podcastindex.PodcastIndexConfigDsl
@@ -24,12 +23,11 @@ public fun PodcastIndexClient(
     block: PodcastIndexClientConfig.() -> Unit = {},
 ): PodcastIndexClient {
     require(userAgent.isNotBlank()) { "User agent cannot be blank" }
-    val auth = Authentication(authKey, authSecret, userAgent)
     val config = PodcastIndexClientConfig().apply { block() }
     return PodcastIndexClient(
         httpClientConfig = {
-            installAuthenticationPlugin(auth)
-            installRetryPlugin(auth, maxRetries = config.maxRetries)
+            installAuthenticationPlugin(authKey, authSecret, userAgent)
+            installRetryPlugin(authKey, authSecret, maxRetries = config.maxRetries)
             installSerializationPlugin()
             if (config.enableLogging) {
                 installLoggingPlugin(config.loggingTag)

--- a/podcastindex-sdk-base/build.gradle.kts
+++ b/podcastindex-sdk-base/build.gradle.kts
@@ -44,7 +44,6 @@ kotlin {
             implementation(libs.ktor2.core)
             implementation(libs.kotlinx.serialization)
             implementation(libs.kotlinx.datetime)
-            implementation(libs.annotation)
         }
 
         jvmMain.dependencies {

--- a/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/InternalPodcastIndexApi.kt
+++ b/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/InternalPodcastIndexApi.kt
@@ -1,0 +1,14 @@
+package com.mr3y.podcastindex
+
+@RequiresOptIn(
+    "This API is internal and is subject to be changed or removed without any prior notice or migration guide",
+    level = RequiresOptIn.Level.WARNING
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class InternalPodcastIndexApi

--- a/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/PodcastIndexClient.kt
+++ b/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/PodcastIndexClient.kt
@@ -1,6 +1,5 @@
 package com.mr3y.podcastindex
 
-import androidx.annotation.RestrictTo
 import com.mr3y.podcastindex.services.Episodes
 import com.mr3y.podcastindex.services.Misc
 import com.mr3y.podcastindex.services.Podcasts
@@ -14,7 +13,7 @@ import io.ktor.client.HttpClientConfig
  * PodcastIndexClient instance responsible for interacting with different PodcastIndex API endpoints.
  */
 public class PodcastIndexClient
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalPodcastIndexApi
 constructor(
     private val httpClientConfig: HttpClientConfig<*>.() -> Unit,
 ) {

--- a/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/PodcastIndexClientConfig.kt
+++ b/podcastindex-sdk-base/src/commonMain/kotlin/com/mr3y/podcastindex/PodcastIndexClientConfig.kt
@@ -1,9 +1,7 @@
 package com.mr3y.podcastindex
 
-import androidx.annotation.RestrictTo
-
 @DslMarker
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalPodcastIndexApi
 public annotation class PodcastIndexConfigDsl
 
 /**
@@ -37,10 +35,3 @@ public class PodcastIndexClientConfig {
      */
     public var defaultTimeout: Long = 10_000
 }
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public data class Authentication(
-    val key: String,
-    val secret: String,
-    val userAgent: String,
-)


### PR DESCRIPTION
- Remove `Authentication` data class.
- Explicitly Annotate `@Dsl` & Client constructor as internal APIs.